### PR TITLE
Add custom embedded objects

### DIFF
--- a/src/mathInput/mathInput.d.ts
+++ b/src/mathInput/mathInput.d.ts
@@ -22,5 +22,6 @@ export type MathInputProps = {
     scrollType?: "window" | "raw";
     lang?: Langs;
     forbidOtherKeyboardKeys?: boolean;
+    registerEmbedObjects?: {id: string, htmlString: string, text: string, latex: string}[];
 };
-export declare const MathInput: ({ numericToolbarKeys, numericToolbarTabs, alphabeticToolbarKeys, setValue, setMathfieldRef, setClearRef, style, initialLatex, rootElementId, divisionFormat, size, fullWidth, allowAlphabeticKeyboard, scrollType, lang, forbidOtherKeyboardKeys, }: MathInputProps) => JSX.Element;
+export declare const MathInput: ({ numericToolbarKeys, numericToolbarTabs, alphabeticToolbarKeys, setValue, setMathfieldRef, setClearRef, style, initialLatex, rootElementId, divisionFormat, size, fullWidth, allowAlphabeticKeyboard, scrollType, lang, forbidOtherKeyboardKeys, registerEmbedObjects}: MathInputProps) => JSX.Element;

--- a/src/mathInput/mathInput.tsx
+++ b/src/mathInput/mathInput.tsx
@@ -28,6 +28,12 @@ export type MathInputProps = {
   scrollType?: "window" | "raw";
   lang?: Langs;
   forbidOtherKeyboardKeys?: boolean;
+  registerEmbedObjects?: {
+    id: string;
+    htmlString: string;
+    text: string;
+    latex: string;
+  }[];
 };
 
 const vanillaKeys = [
@@ -69,6 +75,7 @@ export const MathInput = ({
   scrollType = "window",
   lang = "en",
   forbidOtherKeyboardKeys = false,
+  registerEmbedObjects,
 }: MathInputProps) => {
   const [loaded, setLoaded] = useState(false);
 
@@ -118,7 +125,24 @@ export const MathInput = ({
     window.jQuery = $;
     require("mathquill4keyboard/build/mathquill.css");
     require("mathquill4keyboard/build/mathquill");
-    const MQ = window.MathQuill.getInterface(2);
+    let MQ = window.MathQuill.getInterface(2);
+
+    if (registerEmbedObjects) {
+      registerEmbedObjects.forEach((obj) => {
+        MQ.registerEmbed(obj.id, function registerObject() {
+          return {
+            htmlString: obj.htmlString,
+            text: function text() {
+              return obj.text;
+            },
+            latex: function latex() {
+              return obj.latex;
+            },
+          };
+        });
+      });
+    }
+
     const mf = MQ.MathField(spanRef.current, {
       handlers: {
         edit: function () {


### PR DESCRIPTION
Fixes #9 

This feature enables the ability to add custom embedded objects before the MathField is instantiated. The .registerEmbed() method is part of an experimental feature of the [Mathquill API](https://docs.mathquill.com/en/latest/Api_Methods/#registerembedname-functionid-return-options-x).