### PR TITLE
Handle Double Backslashes in initialLatex prop.

### DIFF
--- a/src/mathInput/mathInput.tsx
+++ b/src/mathInput/mathInput.tsx
@@ -61,6 +61,10 @@ const vanillaKeys = [
   "/",
 ];
 
+const convertDoubleBackslashes = (str: string) => {
+  return str.replace(/\\\\/g, "\\");
+};
+
 export const MathInput = ({
   numericToolbarKeys,
   numericToolbarTabs,
@@ -195,7 +199,7 @@ export const MathInput = ({
   useEffect(() => {
     if (!loaded || !initialLatex) return;
     if (wasInitialLatexSet.current) return;
-    mathfield.current.latex(initialLatex);
+    mathfield.current.latex(convertDoubleBackslashes(initialLatex));
     wasInitialLatexSet.current = true;
   }, [loaded, initialLatex]);
 


### PR DESCRIPTION
Fix: Handle Double Backslashes in Props (Fixes #13 )


**Description:**

This PR addresses the issue where double backslashes in props are not being correctly interpreted as single backslashes within the component. The problem was observed when passing strings with special characters, such as mathematical expressions, to the component.

**Changes Made:**
1. Added a function to the component that uses JavaScript's built-in `String.prototype.replace` method to replace double backslashes (`\\\\`) with single backslashes (`\\`).
2. Updated the component to process the `prop` using this function before rendering.

**Example:**

Before this fix:
- Passing `prop="\\frac{\\int_a^b 2\\pi e^{2ix}\\cos(\\theta) \\gamma}{\\sum_2^9 i^2 - 1}"` would not render correctly.

After this fix:
- The component now correctly interprets the double backslashes and renders `\frac{\int_a^b 2\pi e^{2ix}\cos(\theta) \gamma}{\sum_2^9 i^2 - 1}` as intended.


**Testing:**
- Verified that props with double backslashes as well as single are now correctly converted to single backslashes.
- Ensured that the component renders the expected output with various test strings.

**Impact:**
This fix improves the handling of special characters in props, ensuring that mathematical expressions and other similar strings in initialLatex prop are rendered correctly within the component.
