### PR TITLE
Add equivalent symbol to algebra keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5110,8 +5110,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -5228,7 +5227,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6084,7 +6082,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6108,7 +6105,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6386,7 +6382,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/src/keyboard/keys/algebraKeys.ts
+++ b/src/keyboard/keys/algebraKeys.ts
@@ -97,4 +97,12 @@ export const algebraKeysProps: KeyProps[] = [
     mathfieldInstructions: { content: "x^3", method: "write" },
     groups: ["algebra"],
   },
+  {
+    id: "identity",
+    label: "≡",
+    labelType: "tex",
+
+    mathfieldInstructions: { content: "≡", method: "write" },
+    groups: ["algebra"],
+  },
 ];

--- a/src/keyboard/keys/algebraKeys.ts
+++ b/src/keyboard/keys/algebraKeys.ts
@@ -98,7 +98,7 @@ export const algebraKeysProps: KeyProps[] = [
     groups: ["algebra"],
   },
   {
-    id: "identity",
+    id: "equivalent",
     label: "≡",
     labelType: "tex",
 

--- a/src/keyboard/keys/keyIds.d.ts
+++ b/src/keyboard/keys/keyIds.d.ts
@@ -1,4 +1,4 @@
-export type KeyId = 
+export type KeyId =
 /**quantities */
 "volumeMere" | "volumeFille" | "concentrationMere" | "concentrationFille"
 /**units */
@@ -10,7 +10,7 @@ export type KeyId =
 /**geometry */
  | "overrightarrow" | "degree" | "vectorU"
 /**operations */
- | "plus" | "minus" | "times" | "frac" | "obelus" | "sqrt" | "sqrtCub" | "square" | "cube" | "power" | "percent" | "leftParenthesis" | "leftParenthesisNoLeft" | "rightParenthesis" | "rightParenthesisNoRight" | "equal" | "comma" | "semicolon" | "dot" | "sup" | "inf" | "geq" | "leq" | "approx" | "xsquare" | "xcube"
+ | "plus" | "minus" | "times" | "frac" | "obelus" | "sqrt" | "sqrtCub" | "square" | "cube" | "power" | "percent" | "leftParenthesis" | "leftParenthesisNoLeft" | "rightParenthesis" | "rightParenthesisNoRight" | "equal" | "comma" | "semicolon" | "dot" | "sup" | "inf" | "geq" | "leq" | "approx" | "xsquare" | "xcube" | "identity"
 /**sets */
  | "belongs" | "notin" | "cap" | "cup" | "lbrace" | "rbrace" | "lbracket" | "rbracket" | "varnothing" | "naturals" | "integers" | "rationals" | "decimals" | "reals" | "complex" | "ast" | "del" | "right" | "left" | "rightarrow" | "overrightarrow" | "infty"
 /**fcts */

--- a/src/keyboard/keys/keyIds.d.ts
+++ b/src/keyboard/keys/keyIds.d.ts
@@ -10,7 +10,7 @@ export type KeyId =
 /**geometry */
  | "overrightarrow" | "degree" | "vectorU"
 /**operations */
- | "plus" | "minus" | "times" | "frac" | "obelus" | "sqrt" | "sqrtCub" | "square" | "cube" | "power" | "percent" | "leftParenthesis" | "leftParenthesisNoLeft" | "rightParenthesis" | "rightParenthesisNoRight" | "equal" | "comma" | "semicolon" | "dot" | "sup" | "inf" | "geq" | "leq" | "approx" | "xsquare" | "xcube" | "identity"
+ | "plus" | "minus" | "times" | "frac" | "obelus" | "sqrt" | "sqrtCub" | "square" | "cube" | "power" | "percent" | "leftParenthesis" | "leftParenthesisNoLeft" | "rightParenthesis" | "rightParenthesisNoRight" | "equal" | "comma" | "semicolon" | "dot" | "sup" | "inf" | "geq" | "leq" | "approx" | "xsquare" | "xcube" | "equivalent"
 /**sets */
  | "belongs" | "notin" | "cap" | "cup" | "lbrace" | "rbrace" | "lbracket" | "rbracket" | "varnothing" | "naturals" | "integers" | "rationals" | "decimals" | "reals" | "complex" | "ast" | "del" | "right" | "left" | "rightarrow" | "overrightarrow" | "infty"
 /**fcts */

--- a/src/keyboard/keys/keyIds.ts
+++ b/src/keyboard/keys/keyIds.ts
@@ -63,6 +63,7 @@ export type KeyId =
   | "approx"
   | "xsquare"
   | "xcube"
+  | "identity"
 
   /**sets */
   | "belongs"

--- a/src/keyboard/keys/keyIds.ts
+++ b/src/keyboard/keys/keyIds.ts
@@ -63,7 +63,7 @@ export type KeyId =
   | "approx"
   | "xsquare"
   | "xcube"
-  | "identity"
+  | "equivalent"
 
   /**sets */
   | "belongs"


### PR DESCRIPTION
Adds the equivalent (triple bar symbol ≡ (U+2261, LaTeX \equiv)) used to indicate an identity